### PR TITLE
91 fixing frotend deployment

### DIFF
--- a/frontend/app/artifacts/[type]/[id]/page.tsx
+++ b/frontend/app/artifacts/[type]/[id]/page.tsx
@@ -1,8 +1,14 @@
 import { ArtifactDetailClient } from "./ArtifactDetailClient"
 
-// For static export builds, generate placeholder params
-// Note: dynamicParams is false by default with output: 'export'
+// Disable dynamic params for static export
+// All artifact IDs are handled client-side via the API
+export const dynamicParams = false
+
+// Static export: only generate placeholder routes
+// Actual artifact data is fetched client-side
 export function generateStaticParams(): Array<{ type: string; id: string }> {
+  // Generate one placeholder route per artifact type
+  // S3 will serve these pages, and client-side code handles the actual ID
   return [
     { type: "model", id: "placeholder" },
     { type: "dataset", id: "placeholder" },
@@ -12,12 +18,12 @@ export function generateStaticParams(): Array<{ type: string; id: string }> {
 
 export default async function ArtifactDetailPage({ params }: { params: Promise<{ type: string; id: string }> }) {
   const { type, id } = await params
-  
+
   // Validate type
   if (!['model', 'dataset', 'code'].includes(type)) {
     throw new Error(`Invalid artifact type: ${type}`)
   }
-  
+
   return <ArtifactDetailClient type={type as 'model' | 'dataset' | 'code'} id={id} />
 }
 

--- a/frontend/app/models/[id]/page.tsx
+++ b/frontend/app/models/[id]/page.tsx
@@ -1,11 +1,11 @@
 import { ModelDetailClient } from "./ModelDetailClient"
 
-// For static export builds, generate a placeholder param
-// Note: dynamicParams is false by default with output: 'export'
-// In development, this route will be fully dynamic
+// Disable dynamic params for static export
+export const dynamicParams = false
+
+// Static export: generate placeholder route
+// Actual model data is fetched client-side
 export function generateStaticParams(): Array<{ id: string }> {
-  // Return a placeholder ID so the route structure is generated for static export
-  // The actual model data is fetched client-side, so any ID will work
   return [{ id: "placeholder" }]
 }
 


### PR DESCRIPTION
This pull request updates the routing and static export behavior for artifact and model detail pages. The main change is to disable dynamic route parameter generation for static exports, instead generating only placeholder routes. Actual artifact and model data is now fetched client-side, allowing static hosting solutions (like S3) to serve the pages without pre-generating every possible ID.

Routing and static export changes:

* Disabled dynamic route parameter generation by setting `dynamicParams` to `false` in both `frontend/app/artifacts/[type]/[id]/page.tsx` and `frontend/app/models/[id]/page.tsx`. ([frontend/app/artifacts/[type]/[id]/page.tsxL3-R11](diffhunk://#diff-9d9d1a3108cae8598cffc72a07d2c5ec82443470b0ee3bcece7659e279475501L3-R11), [frontend/app/models/[id]/page.tsxL3-L10](diffhunk://#diff-46679e0b7c2c6264820b058f8a3bb240014feaedc30db63a66cec04bfbb4e0bfL3-L10))
* Updated `generateStaticParams` in both files to return only placeholder routes, ensuring that static export builds generate minimal routes and rely on client-side fetching for actual data. ([frontend/app/artifacts/[type]/[id]/page.tsxL3-R11](diffhunk://#diff-9d9d1a3108cae8598cffc72a07d2c5ec82443470b0ee3bcece7659e279475501L3-R11), [frontend/app/models/[id]/page.tsxL3-L10](diffhunk://#diff-46679e0b7c2c6264820b058f8a3bb240014feaedc30db63a66cec04bfbb4e0bfL3-L10))