### PR TITLE
fixed and tested

### DIFF
--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -257,11 +257,16 @@ export async function fetchHealthComponents(windowMinutes: number = 60, includeT
 export async function startDownloadBenchmark(backendUrl?: string) {
   const baseUrl = backendUrl || API_BASE_URL
   try {
+    // Pass the target URL in the request body so the benchmark downloads
+    // from the correct backend (ECS vs Lambda)
     const response = await fetch(`${baseUrl}/health/download-benchmark/start`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
+      body: JSON.stringify({
+        target_url: baseUrl,  // Tell the backend which URL to benchmark
+      }),
     })
 
     if (!response.ok) {


### PR DESCRIPTION
This pull request enhances the download benchmark endpoint in the backend API to allow clients to specify which backend URL should be benchmarked (e.g., ECS or Lambda). This is achieved by accepting an optional `target_url` in the request body and propagating it through the benchmark process. The frontend is also updated to send this parameter when starting a benchmark. These changes increase flexibility for benchmarking different deployment targets and improve traceability by storing and returning the target URL.

**Backend API enhancements:**

* Added a `StartBenchmarkRequest` Pydantic model to accept an optional `target_url` in the POST request body to `/health/download-benchmark/start`.
* Modified the `start_download_benchmark` endpoint to accept and process the `target_url` parameter, storing it in the job status and including it in the response. [[1]](diffhunk://#diff-3909266c3817d600a7dd46d8e8ba4a9c88d7a804653500460ad2a67110a5364dL267-R297) [[2]](diffhunk://#diff-3909266c3817d600a7dd46d8e8ba4a9c88d7a804653500460ad2a67110a5364dR316-R335) [[3]](diffhunk://#diff-3909266c3817d600a7dd46d8e8ba4a9c88d7a804653500460ad2a67110a5364dL322-R347)
* Updated the `run_download_benchmark_script` function to accept a `target_base_url` argument and use it (falling back to environment variable or default if not provided). [[1]](diffhunk://#diff-3909266c3817d600a7dd46d8e8ba4a9c88d7a804653500460ad2a67110a5364dL152-R160) [[2]](diffhunk://#diff-3909266c3817d600a7dd46d8e8ba4a9c88d7a804653500460ad2a67110a5364dL193-R203)

**Frontend integration:**

* Updated the `startDownloadBenchmark` function in `frontend/lib/api.ts` to send the `target_url` in the request body, ensuring the backend benchmarks the correct deployment.